### PR TITLE
add conditional VPC connector annotation to Cloud Run service feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ provider "google" {
 
 In the example above, replace `<PATH_TO_SERVICE_ACCOUNT_KEY_JSON>` with the path to your Service Account key JSON file and `<PROJECT_ID>` with your GCP Project ID. Also, be aware that you will need to provide a storage location for the Terraform state to be kept in.
 
+## Required APIs
+
+The module requires several Google Cloud APIs to be enabled for the project. Here's a brief description of each:
+
+1. `cloudresourcemanager.googleapis.com`: The Cloud Resource Manager API is a service that enables you to programmatically manage the resource containers (such as Organizations and Projects) that hold your Google Cloud Platform (GCP) resources.
+
+2. `iam.googleapis.com`: The Identity and Access Management (IAM) API enables you to manage access control by defining who (identity) has what access (role) for which resource.
+
+3. `artifactregistry.googleapis.com`: Artifact Registry is a package hosting and delivery service that helps you to manage, secure, and observe packages used in your software development process.
+
+4. `run.googleapis.com`: The Cloud Run API manages instances of your container-based applications and provides built-in mechanisms to scale the instances, inject environment variables, and configure allowed inbound traffic.
+
+5. `vpcaccess.googleapis.com`: The Serverless VPC Access API lets you create connectors that connect Google Cloud serverless services directly to your VPC network. This enables your serverless applications to access resources in your VPC network.
+
+6. `logging.googleapis.com`: The Cloud Logging API allows you to read, write, and configure logs in Google Cloud.
+
+7. `serviceusage.googleapis.com`: The Service Usage API provides methods to enable, disable, list and retrieve service configurations for a project.
+
+_⚠️ These APIs are enabled in the code, and they are not disabled when the resources are destroyed (`disable_on_destroy = false`)._
+
 ## Configuration variables
 
 The module uses the following variables for customization:
@@ -143,10 +163,10 @@ I will do my best to review and respond to your issue in a timely manner.
 Your contributions are always welcome! If you have a fix or improvement you'd like to contribute, you can create a pull request following the standard GitHub process:
 
 1. Fork the repository and create your branch from `main`.
-2. If you've added code that should be tested, add tests.
-3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
-5. Make sure your code lints.
+2. If you've added code that should be tested, add tests and fallbacks.
+3. If you've changed APIs or added variables update the documentation.
+4. Ensure the configuration works and is valid (terraform validate).
+5. Make sure your is formatted correctly (terraform fmt).
 6. Issue that pull request!
 
 By contributing, you agree that your contributions will be licensed under the project's license.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This [Terraform](https://terraform.io) module, **GCP CloudRun VPC Integration Module**, is designed to streamline the deployment of [Google Cloud Run](https://cloud.google.com/run/docs/overview/what-is-cloud-run) services, seamlessly integrated with a [VPC network](https://cloud.google.com/vpc/docs/vpc) and a VPC connector. This module allows you to configure your Cloud Run service to establish secure communication with your VPC resources and private databases within the [Google Cloud Platform (GCP)](https://cloud.google.com) ecosystem.
 
+Please note: The creation of VPC components is optional. Depending on the specific needs of your project, you may choose whether or not to implement these.
+
 ## Prerequisites
 
 Before you begin, ensure you have the following:
@@ -34,6 +36,7 @@ The module uses the following variables for customization:
 
 ### VPC variables
 
+- `enable_vpc`: Set to 1 to enable VPC components to be created; 0 will ignore VPC creation (default: `1`).
 - `vpc_network_name`: Name of the VPC network to be created (default: `vpc-network`).
 - `vpc_subnet_name`: Name of the VPC subnet to be created (default: `vpc-sub-network`).
 - `vpc_subnet_ip_cidr_range`: IP CIDR range for the VPC subnet (default: `10.0.0.0/24`).

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The module uses the following variables for customization:
 - `cloud_run_container_port`: Port on which the Cloud Run service will listen (default: `80`).
 - `cloud_run_max_scale`: Maximum number of containers that can be scaled up (default: `5`).
 - `cloud_run_min_scale`: Minimum number of containers that can be scaled up (default: `0`).
-- `cloud_run_vpc_access_egress`: Controls outbound network access for the Cloud Run service (default: `private-ranges-only`).
+- `cloud_run_vpc_access_egress`: Controls outbound network access for the Cloud Run service (default: `private-ranges-only`) _⚠️ This feature will only be used when "enable_vpc" is set to "1"._
 - `cloud_run_vpc_access_ingress`: Manages inbound network access for the Cloud Run service (default: `internal-and-cloud-load-balancing`).
 - `cloud_run_cpu_throttling`: Degree to which the CPU usage of the Cloud Run service is limited during resource allocation (default: `true`).
 - `cloud_run_session_affinity`: Degree to which requests from a client should be directed to the same container (default: `true`).
@@ -118,6 +118,38 @@ module "cloud_run_vpc_integration" {
 ```
 
 2. Initialize and apply the changes.
+
+## Reporting Issues
+
+As the maintainer of this Terraform module, I highly appreciate your feedback. If you encounter any issues, I encourage you to report them. 
+
+To create a new issue, please follow these steps:
+
+1. Navigate to the **Issues** tab in the GitHub repository and click on the **New issue** button.
+2. In the issue description, please provide as much relevant information as possible, such as:
+   - Terraform version
+   - Provider versions (Google, etc.)
+   - A brief description of the issue
+   - Step-by-step instructions to reproduce the issue
+   - Relevant code and configurations
+   - Error messages and screenshots
+3. If possible, label your issue appropriately.
+4. Finally, click **Submit new issue** to create the issue.
+
+I will do my best to review and respond to your issue in a timely manner. 
+
+## Contributing
+
+Your contributions are always welcome! If you have a fix or improvement you'd like to contribute, you can create a pull request following the standard GitHub process:
+
+1. Fork the repository and create your branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. Issue that pull request!
+
+By contributing, you agree that your contributions will be licensed under the project's license.
 
 ## Show Your Support
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
-# Services enabled by the module
-resource "google_project_service" "project-services" {
+# Enable necessary Google Cloud Services for the project
+resource "google_project_service" "project_services" {
   for_each = toset([
     "cloudresourcemanager.googleapis.com",
     "iam.googleapis.com",
@@ -13,77 +13,93 @@ resource "google_project_service" "project-services" {
   project            = var.project_id
   disable_on_destroy = false
 }
-# VPC components
+
+# Create a VPC network if enable_vpc is set to 1 (true)
 resource "google_compute_network" "vpc_network" {
-  count                   = var.enable_vpc
+  count                   = var.enable_vpc == 1 ? 1 : 0 # Fallback to 0 if enable_vpc is not 1
   name                    = var.vpc_network_name
   auto_create_subnetworks = false
 }
+
+# Create a subnetwork for the VPC network if enable_vpc is set to 1 (true)
 resource "google_compute_subnetwork" "vpc_subnetwork" {
-  count         = var.enable_vpc
+  count         = var.enable_vpc == 1 ? 1 : 0 # Fallback to 0 if enable_vpc is not 1
   name          = var.vpc_subnet_name
   region        = var.region
   ip_cidr_range = var.vpc_subnet_ip_cidr_range
-  network       = google_compute_network.vpc_network.id
+  network       = google_compute_network.vpc_network[0].id
   depends_on    = [google_compute_network.vpc_network]
 }
+
+# Create a VPC Access Connector subnetwork if enable_vpc is set to 1 (true)
 resource "google_compute_subnetwork" "vpc_access_connector_subnet" {
-  count         = var.enable_vpc
-  name          = var.vpc_connector_subnet_name
+  count         = var.enable_vpc == 1 ? 1 : 0 # Fallback to 0 if enable_vpc is not 1
+  name          = google_compute_network.vpc_network[0].name
   region        = var.region
   ip_cidr_range = var.vpc_connector_subnet_ip_cidr_range
-  network       = google_compute_network.vpc_network.id
+  network       = google_compute_network.vpc_network[0].id
   depends_on    = [google_compute_network.vpc_network]
 }
+
+# Create a VPC Access Connector if enable_vpc is set to 1 (true)
 resource "google_vpc_access_connector" "vpc_access_connector" {
-  count        = var.enable_vpc
+  count        = var.enable_vpc == 1 ? 1 : 0 # Fallback to 0 if enable_vpc is not 1
   name         = var.vpc_connector_name
   region       = var.region
   machine_type = var.vpc_connector_machine_type
+
   subnet {
-    name = google_compute_subnetwork.vpc_access_connector_subnet.name
+    name = google_compute_subnetwork.vpc_access_connector_subnet[0].name
   }
 }
-# VPC components toggle
+
+# Define common annotations used across the Cloud Run service
 locals {
   common_annotations = {
-    # Scaling behaviour
-    "autoscaling.knative.dev/maxScale" = var.cloud_run_max_scale
-    "autoscaling.knative.dev/minScale" = var.cloud_run_min_scale
-    "run.googleapis.com/vpc-access-egress" = var.cloud_run_vpc_access_egress
-    # Set to true to enable CPU allocation only during request processing
-    "run.googleapis.com/cpu-throttling" = var.cloud_run_cpu_throttling
-    # Set to true to enable requests from a client to be directed to the same container
-    "run.googleapis.com/sessionAffinity" = var.cloud_run_session_affinity
-    # Set to true to enable CPU boosts to reduce startup time
+    "autoscaling.knative.dev/maxScale"     = var.cloud_run_max_scale
+    "autoscaling.knative.dev/minScale"     = var.cloud_run_min_scale
+    "run.googleapis.com/cpu-throttling"    = var.cloud_run_cpu_throttling
+    "run.googleapis.com/sessionAffinity"   = var.cloud_run_session_affinity
     "run.googleapis.com/startup-cpu-boost" = var.cloud_run_cpu_boost
   }
+
   vpc_connector_annotation = var.enable_vpc == 1 ? {
     "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.vpc_access_connector[0].name
   } : {}
+
+  vpc_access_egress_annotation = var.enable_vpc == 1 ? {
+    "run.googleapis.com/vpc-access-egress" = var.cloud_run_vpc_access_egress
+  } : {}
 }
-# CloudRun Service
+
+# Create a Cloud Run service
 resource "google_cloud_run_service" "cloud_run_service" {
   name     = var.cloud_run_service_name
   location = var.region
   project  = var.project_id
+
   metadata {
     namespace = var.project_id
+
     annotations = {
       "run.googleapis.com/ingress" = var.cloud_run_vpc_access_ingress
     }
   }
+
   traffic {
     percent         = 100
     latest_revision = true
   }
+
   template {
     spec {
       container_concurrency = var.cloud_run_container_concurrency
       timeout_seconds       = var.cloud_run_timeout_seconds
       service_account_name  = var.cloud_run_service_account
+
       containers {
         image = var.cloud_run_service_image_location
+
         resources {
           requests = {
             cpu    = var.cloud_run_cpu_request
@@ -94,22 +110,25 @@ resource "google_cloud_run_service" "cloud_run_service" {
             memory = var.cloud_run_memory_limit
           }
         }
+
         ports {
           container_port = var.cloud_run_container_port
         }
       }
     }
+
     metadata {
       labels = {
         "environment" : terraform.workspace
         "run.googleapis.com/startupProbeType" = "Default"
       }
-      annotations = merge(local.common_annotations, local.vpc_connector_annotation)
+      annotations = merge(local.common_annotations, local.vpc_connector_annotation, local.vpc_access_egress_annotation)
     }
   }
   autogenerate_revision_name = true
 }
-# allow unauthenticated Requests
+
+# Allow unauthenticated requests to the Cloud Run service
 data "google_iam_policy" "noauth" {
   binding {
     role = "roles/run.invoker"
@@ -118,6 +137,7 @@ data "google_iam_policy" "noauth" {
     ]
   }
 }
+
 resource "google_cloud_run_service_iam_policy" "noauth-env" {
   location    = google_cloud_run_service.cloud_run_service.location
   project     = google_cloud_run_service.cloud_run_service.project

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ resource "google_vpc_access_connector" "vpc_access_connector" {
     name = google_compute_subnetwork.vpc_access_connector_subnet.name
   }
 }
+# VPC components toggle
 locals {
   common_annotations = {
     # Scaling behaviour
@@ -61,6 +62,7 @@ locals {
     "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.vpc_access_connector[0].name
   } : {}
 }
+# CloudRun Service
 resource "google_cloud_run_service" "cloud_run_service" {
   name     = var.cloud_run_service_name
   location = var.region

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,11 @@ variable "region" {
 
 # VPC variables
 
+variable "enable_vpc" {
+  description = "Whether the VPC components are created"
+  default     = 1
+}
+
 variable "vpc_network_name" {
   description = "The name of the VPC network to create."
   default     = "vpc-network"


### PR DESCRIPTION
Introduces a conditional for the 'run.googleapis.com/vpc-access-connector' 
annotation in the Cloud Run service Terraform code. Now, the annotation will only 
be included if the 'enable_vpc' variable is set to 1. This ensures compatibility 
with setups that do not utilize VPCs. Other annotations are not affected by this change.